### PR TITLE
bash raise on error

### DIFF
--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -993,7 +993,7 @@
    "id": "44bce6b9",
    "metadata": {},
    "source": [
-    "Instead of raising an exception, it's best to return a success/error dict. The functions in this section wrap `safe_run` in this way, and provide documentation suitable for an LLM."
+    "The functions in this section wrap `safe_run` suitable for LLM usage."
    ]
   },
   {
@@ -1009,21 +1009,22 @@
     "    as_dict:bool=False, # Return a dict response with 'success' or 'error' key\n",
     "    rm_cmds:str=None,  # Temp remove these commands from allow list\n",
     "    rm_dests:str=None  # Temp remove these destinations from allow list\n",
-    "): # dict with 'success' or 'error' key; value is stdout+stderr for success, or error message otherwise\n",
+    "):\n",
     "    \"\"\"Run a bash shell command line safely and return the concatencated stdout and stderr.\n",
     "    Since it is run with `bash`, special chars like `$` and `*` are handled by the shell, so must be quoted if literal.\n",
     "    `cmd` is parsed and all calls are checked against an allow-list.\n",
-    "    If the command is not allowed, STOP and inform the user of the command run and error details; so they can decide whether to whitelist\n",
-    "    it or run it themselves.\n",
     "    The default allow-list includes most standard unix commands and git subcommands that do not change state or are easily reverted.\n",
     "    All operators are supported. Output redirects are validated against allowed destinations (default: ./ and /tmp).\n",
     "    rm_ params are comma-separated strs.\"\"\"\n",
     "    try: res = safe_run(cmd, rm_cmds=rm_cmds, rm_dests=rm_dests)\n",
     "    except PermissionError as e:\n",
     "        eff_cmds, eff_dests = _eff_sets(rm_cmds=rm_cmds, rm_dests=rm_dests)\n",
-    "        return dict(error=e, allowed_cmds=joins('; ', eff_cmds), allowed_dests=joins('; ', eff_dests),\n",
-    "            suggestion='rerun using an allowed tool/dest, or ask user to provide permission')\n",
-    "    return {'success': res} if as_dict else res"
+    "        e.add_note(f'''\\\n",
+    "allowed_cmds: {joins('; ', eff_cmds)}\n",
+    "allowed_dests: {joins('; ', eff_dests)}\n",
+    "suggestion: rerun using an allowed tool/dest, or ask user to provide permission''')\n",
+    "        raise\n",
+    "    return res"
    ]
   },
   {
@@ -1057,44 +1058,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1795efea",
+   "id": "02e9c128",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DisallowedCmd('head -2')"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "r = bash('ls | head -2', rm_cmds='head')\n",
-    "r['error']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5cf6911f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['error', 'allowed_cmds', 'allowed_dests', 'suggestion']"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "list(r)"
+    "try: bash('ls | head -2', rm_cmds='head')\n",
+    "except DisallowedCmd as e: assert any('allowed_cmds' in n for n in e.__notes__)\n",
+    "else: assert False, \"expected DisallowedCmd\""
    ]
   },
   {
@@ -1102,20 +1072,9 @@
    "execution_count": null,
    "id": "b60a3476",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DisallowedCmd('sudo ls')"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "bash('sudo ls')['error']"
+    "test_fail(bash,args=('sudo ls',),exc=DisallowedCmd)"
    ]
   },
   {
@@ -1201,20 +1160,9 @@
    "execution_count": null,
    "id": "d53a1a87",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DisallowedCmd('ls -l')"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "bash('ls -l')['error']"
+    "test_fail(bash,args=('ls -l',),exc=DisallowedCmd)"
    ]
   },
   {

--- a/safecmd/core.py
+++ b/safecmd/core.py
@@ -314,21 +314,22 @@ def bash(
     as_dict:bool=False, # Return a dict response with 'success' or 'error' key
     rm_cmds:str=None,  # Temp remove these commands from allow list
     rm_dests:str=None  # Temp remove these destinations from allow list
-): # dict with 'success' or 'error' key; value is stdout+stderr for success, or error message otherwise
+):
     """Run a bash shell command line safely and return the concatencated stdout and stderr.
     Since it is run with `bash`, special chars like `$` and `*` are handled by the shell, so must be quoted if literal.
     `cmd` is parsed and all calls are checked against an allow-list.
-    If the command is not allowed, STOP and inform the user of the command run and error details; so they can decide whether to whitelist
-    it or run it themselves.
     The default allow-list includes most standard unix commands and git subcommands that do not change state or are easily reverted.
     All operators are supported. Output redirects are validated against allowed destinations (default: ./ and /tmp).
     rm_ params are comma-separated strs."""
     try: res = safe_run(cmd, rm_cmds=rm_cmds, rm_dests=rm_dests)
     except PermissionError as e:
         eff_cmds, eff_dests = _eff_sets(rm_cmds=rm_cmds, rm_dests=rm_dests)
-        return dict(error=e, allowed_cmds=joins('; ', eff_cmds), allowed_dests=joins('; ', eff_dests),
-            suggestion='rerun using an allowed tool/dest, or ask user to provide permission')
-    return {'success': res} if as_dict else res
+        e.add_note(f'''\
+allowed_cmds: {joins('; ', eff_cmds)}
+allowed_dests: {joins('; ', eff_dests)}
+suggestion: rerun using an allowed tool/dest, or ask user to provide permission''')
+        raise
+    return res
 
 # %% ../nbs/01_core.ipynb #1ed78ed3
 def unsafe_bash(


### PR DESCRIPTION
The goal of this PR is to make the behavior of `bash` similar to `pyrun`. Specifically, to raise a `PermissionError` directly instead of surpressing it. For example, SolveIt then inserts a code message that the user can run directly on that event.

@ncoop57 this will require an update in `shell_sage`, because it does not expect the error to be raised.

Perhaps a middle ground could be to make the exception raise a flag in the bash function?

P.S. tests fail on main but these changes dont introduce any new errors.