### PR TITLE
Allow /dev/null as a default safe destination

### DIFF
--- a/nbs/01_core.ipynb
+++ b/nbs/01_core.ipynb
@@ -522,7 +522,7 @@
     "    cp = ConfigParser()\n",
     "    cp.read_string(cfg_str)\n",
     "    cfg = cp['DEFAULT']\n",
-    "    ok_dests = _split_set(cfg.get('ok_dests', './, /tmp'))\n",
+    "    ok_dests = _split_set(cfg.get('ok_dests', './, /dev/null, /tmp'))\n",
     "    splitcmds = ','.join(cfg['ok_cmds'].splitlines())\n",
     "    ok_cmds = _split_specs(splitcmds)\n",
     "    return ok_dests, ok_cmds"

--- a/safecmd/core.py
+++ b/safecmd/core.py
@@ -197,7 +197,7 @@ def parse_cfg(cfg_str):
     cp = ConfigParser()
     cp.read_string(cfg_str)
     cfg = cp['DEFAULT']
-    ok_dests = _split_set(cfg.get('ok_dests', './, /tmp'))
+    ok_dests = _split_set(cfg.get('ok_dests', './, /dev/null, /tmp'))
     splitcmds = ','.join(cfg['ok_cmds'].splitlines())
     ok_cmds = _split_specs(splitcmds)
     return ok_dests, ok_cmds


### PR DESCRIPTION
Add /dev/null to the default ok_dests in parse_cfg so commands may redirect output to /dev/null without an explicit config entry. /dev/null is a universally safe sink for discarding output, so it belongs in the built-in defaults alongside ./ and /tmp.